### PR TITLE
Prevent modal overflow and enable inline playback

### DIFF
--- a/src/shared/components/Modal.jsx
+++ b/src/shared/components/Modal.jsx
@@ -9,7 +9,7 @@ export const Modal = ({ onConfirm }) => {
             onClick={onConfirm}
         >
             <div
-                className="bg-white border p-4 mx-6 flex flex-col max-w-sm w-full h-[70vh] relative"
+                className="bg-white border p-4 mx-6 flex flex-col max-w-sm w-full h-[70vh] relative overflow-hidden"
                 onClick={(e) => e.stopPropagation()}
             >
                 <h3 className="text-2xl text-center text-dark-blue w-full absolute top-10 left-1/2 -translate-x-1/2">
@@ -21,6 +21,7 @@ export const Modal = ({ onConfirm }) => {
                         src={canReadyComp} 
                         alt="Din färdiga burk"
                         className="max-h-full max-w-full object-contain"
+                        playsInline
                         autoPlay
                         muted
                     />


### PR DESCRIPTION
Add overflow-hidden to the modal content wrapper to ensure child content is contained and avoid visual overflow/scrollbars. Add playsInline to the video element so it can autoplay inline on mobile browsers (used with existing autoPlay and muted attributes).